### PR TITLE
Fix: wrong array for \array_map, causing undefined array keys

### DIFF
--- a/src/Services/FontAwesome.php
+++ b/src/Services/FontAwesome.php
@@ -71,8 +71,8 @@ final class FontAwesome implements Htmlable, \Stringable
             '<%s %s>',
             \implode(' ', \array_map(
                 fn ($_) => (\is_int($_)
-                    ? $attrs[$_]
-                    : sprintf('%s="%s"', $_, $attrs[$_])
+                    ? $a[$_]
+                    : sprintf('%s="%s"', $_, $a[$_])
                 ),
                 \array_keys($a),
             )) . match ($el) {


### PR DESCRIPTION
# Description

Fix: wrong array for \array_map, causing undefined array keys

Please tick the following options that are relevant to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Self-checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works