### PR TITLE
Chore: add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts=^${{ matrix.laravel }}" --dev --no-update
+          composer require "illuminate/support=^${{ matrix.laravel }}" --dev --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/support=^${{ matrix.laravel }}" --dev --no-update
+          composer require "illuminate/support=^${{ matrix.laravel }}" --no-interaction --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.1, 8.2, 8.3]
+        laravel: [10, 11]
+        exclude:
+          - php: 8.1
+            laravel: 11
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip
+          ini-values: error_reporting=E_ALL
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "illuminate/contracts=^${{ matrix.laravel }}" --dev --no-update
+          composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 PT Cels Teknologi Indonesia
+Copyright (c) 2024 PT Cels Teknologi Indonesia
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "friendsofphp/php-cs-fixer": "^3.4",
     "mockery/mockery": "^1.4.4",
     "orchestra/testbench": "^8.0|^9.0",
-    "phpunit/phpunit": "^9.5.10"
+    "phpunit/phpunit": "^9.5.10|^10.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,17 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.4",
     "mockery/mockery": "^1.4.4",
-    "orchestra/testbench": "^7.0",
+    "orchestra/testbench": "^8.0|^9.0",
     "phpunit/phpunit": "^9.5.10"
   },
   "autoload": {
     "psr-4": {
       "Cels\\Utilities\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Cels\\Utilities\\Tests\\": "tests/"
     }
   },
   "extra": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/CSPTest.php
+++ b/tests/CSPTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Cels\Utilities\Tests;
+
+use Cels\Utilities\CSP\CSP;
+use Cels\Utilities\CSP\Middleware\AddCSPHeaders;
+
+class CSPTest extends TestCase
+{
+    /**
+     * A basic test to ensure Content-Security-Policy header is set.
+     *
+     * @return void
+     */
+    public function test_that_csp_header_exists()
+    {
+        CSP::$enabled = true;
+
+        app('router')
+            ->middleware([AddCSPHeaders::class])
+            ->get('/', fn () => 'Hello, world!');
+
+        $response = $this->get('/');
+
+        $response->assertHeader('Content-Security-Policy');
+
+        CSP::$enabled = false;
+    }
+}

--- a/tests/Directives/FontAwesomeTest.php
+++ b/tests/Directives/FontAwesomeTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Cels\Utilities\Tests\Directives;
+
+use Cels\Utilities\CSP\CSP;
+use Cels\Utilities\Tests\TestCase;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+use Mockery as m;
+
+class FontAwesomeTest extends TestCase
+{
+    /**
+     * @var Filesystem|m\MockInterface
+     */
+    private $filesystem;
+
+    /**
+     * @var BladeCompiler
+     */
+    protected $compiler;
+
+    private const VALID_ELEMENT_REGEX = '/^<(\w+)\s([\w\-]+(=".*?")?\s?)+?\/?>(<\/\1>)?$/';
+    private const CAPTURE_ATTRIBUTES_REGEX = '/^<(\w+)\s(.+?)\/?>(<\/\1>)?$/';
+    private const CAPTURE_ATTRIBUTE_REGEX = '/[\w\-]+(=".*?")?/';
+
+    public function test_that_directive_can_be_rendered(): void
+    {
+        $result = $this->compiler->render('@fontawesome');
+
+        $matches = [];
+        $this->assertGreaterThan(0, \preg_match(
+            self::VALID_ELEMENT_REGEX,
+            $result,
+            $matches,
+        ));
+        // should contain at least: [$result, 'script', 'src', '="url"', '</script>']
+        $this->assertCount(5, $matches);
+        
+        $attributes = $this->attributes($result);
+        $this->assertArrayHasKey('src', $attributes);
+        $this->assertSame($attributes['src'], \filter_var($attributes['src'], FILTER_VALIDATE_URL));
+    }
+
+    public function test_that_directive_uses_correct_nonce(): void
+    {
+        CSP::$enabled = true;
+        $nonce = CSP::nonce();
+
+        $result = $this->compiler->render('@fontawesome');
+
+        $attributes = $this->attributes($result);
+        $this->assertArrayHasKey('nonce', $attributes);
+        $this->assertSame($nonce, $attributes['nonce']);
+
+        CSP::$enabled = false;
+    }
+
+    public function test_that_directive_renders_correct_subset(): void
+    {
+        $result = $this->compiler->render('@fontawesome(["brands", "solid", "regular"])');
+        $fileSrcs = \array_map(
+            fn ($_) => \array_pop($_),
+            \array_map(
+                fn ($_) => \explode('/', $this->attributes("{$_}>")['src']),
+                \array_filter(\preg_split('/>(?!<\/)/', $result))
+            ),
+        );
+        $this->assertCount(0, \array_filter(\array_map(
+            fn ($_) => \in_array($_, $fileSrcs),
+            ['brands.min.js', 'solid.min.js', 'regular.min.js', 'fontawesome.min.js'],
+        ), fn ($_) => ! $_));
+    }
+
+    public function test_that_directive_renders_correct_subset_with_csp(): void
+    {
+        CSP::$enabled = true;
+        $nonce = CSP::nonce();
+
+        $result = $this->compiler->render('@fontawesome(["brands", "solid", "regular"])');
+        $this->assertCount(0, \array_filter(
+            \array_map(
+                fn ($_) => $this->attributes("{$_}>")['nonce'],
+                \array_filter(\preg_split('/>(?!<\/)/', $result))
+            ),
+            fn ($_) => $_ !== $nonce,
+        ));
+
+        CSP::$enabled = false;
+    }
+
+    // @todo: Check that custom kits & hosts config work
+
+    protected function attributes(string $element): array
+    {
+        $matches = [];
+        \preg_match(self::CAPTURE_ATTRIBUTES_REGEX, $element, $matches);
+        $attributes = [];
+        $r = $matches[2];
+        do {
+            $matches = [];
+            if (\preg_match(self::CAPTURE_ATTRIBUTE_REGEX, \trim($r), $matches) > 0) {
+                $r = \mb_substr(\trim($r), \mb_strlen($matches[0]));
+                $a = \explode('=', $matches[0]);
+                $attributes[\mb_strtolower(\array_shift($a))] = \mb_substr(\implode('=', $a), 1, -1);
+            }
+        } while ($r);
+
+        return $attributes;
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->filesystem = m::mock(Filesystem::class);
+        $this->compiler = new BladeCompiler($this->filesystem, __DIR__);
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Cels\Utilities\Tests;
+
+use Cels\Utilities\ServiceProvider;
+use Illuminate\Testing\TestResponse;
+use Orchestra\Testbench\TestCase as TestbenchTestCase;
+
+abstract class TestCase extends TestbenchTestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            ServiceProvider::class,
+        ];
+    }
+}


### PR DESCRIPTION
# Description

Feature: `@fontawesome` is now compatible with CSP in subsets
Fix: `sprintf` requires 3 arguments but only 2 passed
Chore: add tests for `@fontawesome` Blade directive and CSP headers (WIP)

## Type of change

Please tick the following options that are relevant to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

- CSPTest: tests that the header is added correctly (WIP)
- Directives/FontAwesomeTest.php: tests that the directive renders correctly according to config (WIP)

# Self-checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works