### PR TITLE
Fix: fontawesome subsets require 'fontawesome.min.js' to be included

### DIFF
--- a/src/Services/FontAwesome.php
+++ b/src/Services/FontAwesome.php
@@ -38,16 +38,23 @@ final class FontAwesome
         }
 
         if (\count($args) > 0) {
-            return \implode('', \array_map(
-                fn ($_) => $this->buildElement([
-                    'src' => "{$host}/js/{$_}.min.js",
+            return \implode('', [
+                $this->buildElement([
+                    'src' => "{$host}/js/fontawesome.min.js",
                     ...(CSP::$enabled ? ['data-auto-add-css' => 'false'] : []),
                 ]),
-                $args,
-            )) . (CSP::$enabled ? $this->buildElement([
-                'rel' => 'stylesheet',
-                'href' => "{$host}/css/svg-with-js.min.css"
-            ], 'link') : $this->buildElement(['src' => "{$host}/js/fontawesome.min.js"]));
+                ...\array_map(
+                    fn ($_) => $this->buildElement([
+                        'src' => "{$host}/js/{$_}.min.js",
+                        ...(CSP::$enabled ? ['data-auto-add-css' => 'false'] : []),
+                    ]),
+                    $args,
+                ),
+                (CSP::$enabled ? $this->buildElement([
+                    'rel' => 'stylesheet',
+                    'href' => "{$host}/css/svg-with-js.min.css"
+                ], 'link') : ''),
+            ]);
         }
         return $this->buildElement(['src' => $kit ?: "{$host}/js/all.min.js"]);
     }


### PR DESCRIPTION
# Description

Fix: fontawesome subsets require 'fontawesome.min.js' to be included

## Type of change

Please tick the following options that are relevant to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Self-checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works