### PR TITLE
Fix: use PKCE_METHOD_S256 by default

### DIFF
--- a/src/OAuth2/CelsIdentityProvider.php
+++ b/src/OAuth2/CelsIdentityProvider.php
@@ -65,6 +65,14 @@ class CelsIdentityProvider extends AbstractProvider
     {
         return ' ';
     }
+
+    /**
+     * @return string|null
+     */
+    protected function getPkceMethod()
+    {
+        return self::PKCE_METHOD_S256;
+    }
     
     /**
      * Get the default scopes used by this provider.


### PR DESCRIPTION
# Description

Sets default PKCE Method to SHA256.

# Self-checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works